### PR TITLE
createJSON now uses foreach 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Depends:
     proxy,
     plyr (>= 1.8.1),
     reshape2,
-    RJSONIO
+    RJSONIO,
+    foreach
 License: MIT
 Suggests:
     topicmodels,


### PR DESCRIPTION
To make createJSON run faster I've parallelized it using foreach. If no parallel backend is registered the function behaves as usual. Otherwise it creates term.vectors in parallel.
