### PR TITLE
Added encoding argument to serVis()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: LDAvis
 Title: Interactive Visualization of Topic Models
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(person("Carson", "Sievert", role = c("aut", "cre"), email =
     "cpsievert1@gmail.com"), person("Kenny", "Shirley", role = "aut",
     email = "kshirley@research.att.com"))

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
   CHANGES IN LDAvis VERSION 0.3.4
 
-A new argument, utf8, was added to serVis(). This fixes an issue where, when running on windows, the JSON output would be encoded in ANSI despite the R data beeing encoded in UTF-8. This should also fix #50.
+A new argument, encoding, was added to serVis(). This sets the encoding which will be used to write the JSON file. This may be set to `UTF-8` to  fix an issue where, when running on windows, the JSON output would be encoded in ANSI despite the R data beeing encoded in UTF-8. This should also fix #50.
 
   CHANGES IN LDAvis VERSION 0.3.3
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+  CHANGES IN LDAvis VERSION 0.3.4
+
+A new argument, utf8, was added to serVis(). This fixes an issue where, when running on windows, the JSON output would be encoded in ANSI despite the R data beeing encoded in UTF-8. This should also fix #50.
+
   CHANGES IN LDAvis VERSION 0.3.3
 
 A new argument, reorder.topics, was added to createJSON(). For details, see #51

--- a/R/serVis.R
+++ b/R/serVis.R
@@ -35,7 +35,7 @@
 #' }
 
 serVis <- function(json, out.dir = tempfile(), open.browser = interactive(), 
-                   as.gist = FALSE, language = "english", ...) {
+                   as.gist = FALSE, language = "english", use.bytes = FALSE, ...) {
 
   stopifnot(is.character(language), length(language) == 1, language %in% c('english', 'polish'))
   
@@ -63,7 +63,13 @@ serVis <- function(json, out.dir = tempfile(), open.browser = interactive(),
   }
   
   ## Write json to out.dir
-  cat(json, file = file.path(out.dir, "lda.json"))
+  if (use.bytes) {
+    # This will make the json utf-8 if we are on windows and the inputs were utf-8 encoded
+	  writeLines(json, con = file.path(out.dir, "lda.json"), useBytes = TRUE)
+  }
+  else {
+    cat(json, file = file.path(out.dir, "lda.json"))
+  }
   
   ## Try to upload gist
   if (as.gist) {

--- a/R/serVis.R
+++ b/R/serVis.R
@@ -21,7 +21,7 @@
 #' details, see \url{https://github.com/ropensci/gistr#authentication}.
 #' @param ... arguments passed onto \code{gistr::gist_create}
 #' @param language Which language to use in visualization? So far: \code{english} or \code{polish}.
-#' @param utf8 Should the output be forced to be UTF-8 encoded?
+#' @param encoding Sets the encoding to be used when writing the JSON file.
 #'
 #' @return An invisible object.
 #' @seealso \link{createJSON}
@@ -36,7 +36,7 @@
 #' }
 
 serVis <- function(json, out.dir = tempfile(), open.browser = interactive(), 
-                   as.gist = FALSE, language = "english", utf8 = FALSE, ...) {
+                   as.gist = FALSE, language = "english", encoding = getOption("encoding"), ...) {
 
   stopifnot(is.character(language), length(language) == 1, language %in% c('english', 'polish'))
   
@@ -64,13 +64,7 @@ serVis <- function(json, out.dir = tempfile(), open.browser = interactive(),
   }
   
   ## Write json to out.dir
-  if (utf8) {
-    # This will make the json utf-8 if we are on windows and the inputs were utf-8 encoded
-	con <- file(file.path(out.dir, "lda.json"), encoding = "UTF-8")	  
-  }
-  else {
-	con <- file(file.path(out.dir, "lda.json"))
-  }
+  con <- file(file.path(out.dir, "lda.json"), encoding = encoding)	  
   on.exit(close.connection(con))
   cat(json, file = con)
 

--- a/R/serVis.R
+++ b/R/serVis.R
@@ -21,7 +21,7 @@
 #' details, see \url{https://github.com/ropensci/gistr#authentication}.
 #' @param ... arguments passed onto \code{gistr::gist_create}
 #' @param language Which language to use in visualization? So far: \code{english} or \code{polish}.
-#' @param use.utf-8 Should the output be forced to be UTF-8 encoded?
+#' @param utf8 Should the output be forced to be UTF-8 encoded?
 #'
 #' @return An invisible object.
 #' @seealso \link{createJSON}
@@ -36,7 +36,7 @@
 #' }
 
 serVis <- function(json, out.dir = tempfile(), open.browser = interactive(), 
-                   as.gist = FALSE, language = "english", use.utf-8 = FALSE, ...) {
+                   as.gist = FALSE, language = "english", utf8 = FALSE, ...) {
 
   stopifnot(is.character(language), length(language) == 1, language %in% c('english', 'polish'))
   
@@ -64,7 +64,7 @@ serVis <- function(json, out.dir = tempfile(), open.browser = interactive(),
   }
   
   ## Write json to out.dir
-  if (use.utf-8) {
+  if (utf8) {
     # This will make the json utf-8 if we are on windows and the inputs were utf-8 encoded
 	con <- file(file.path(out.dir, "lda.json"), encoding = "UTF-8")	  
   }

--- a/R/serVis.R
+++ b/R/serVis.R
@@ -21,7 +21,8 @@
 #' details, see \url{https://github.com/ropensci/gistr#authentication}.
 #' @param ... arguments passed onto \code{gistr::gist_create}
 #' @param language Which language to use in visualization? So far: \code{english} or \code{polish}.
-#' 
+#' @param use.utf-8 Should the output be forced to be UTF-8 encoded?
+#'
 #' @return An invisible object.
 #' @seealso \link{createJSON}
 #' @export
@@ -35,7 +36,7 @@
 #' }
 
 serVis <- function(json, out.dir = tempfile(), open.browser = interactive(), 
-                   as.gist = FALSE, language = "english", use.bytes = FALSE, ...) {
+                   as.gist = FALSE, language = "english", use.utf-8 = FALSE, ...) {
 
   stopifnot(is.character(language), length(language) == 1, language %in% c('english', 'polish'))
   
@@ -63,14 +64,16 @@ serVis <- function(json, out.dir = tempfile(), open.browser = interactive(),
   }
   
   ## Write json to out.dir
-  if (use.bytes) {
+  if (use.utf-8) {
     # This will make the json utf-8 if we are on windows and the inputs were utf-8 encoded
-	  writeLines(json, con = file.path(out.dir, "lda.json"), useBytes = TRUE)
+	con <- file(file.path(out.dir, "lda.json"), encoding = "UTF-8")	  
   }
   else {
-    cat(json, file = file.path(out.dir, "lda.json"))
+	con <- file(file.path(out.dir, "lda.json"))
   }
-  
+  on.exit(close.connection(con))
+  cat(json, file = con)
+
   ## Try to upload gist
   if (as.gist) {
     gistd <- requireNamespace('gistr')

--- a/man/serVis.Rd
+++ b/man/serVis.Rd
@@ -5,7 +5,7 @@
 \title{View and/or share LDAvis in a browser}
 \usage{
 serVis(json, out.dir = tempfile(), open.browser = interactive(),
-  as.gist = FALSE, language = "english", ...)
+  as.gist = FALSE, language = "english", use.bytes = FALSE, ...)
 }
 \arguments{
 \item{json}{character string output from \link{createJSON}.}
@@ -22,6 +22,10 @@ interactive login if the GITHUB_PAT environment variable is not set. For more
 details, see \url{https://github.com/ropensci/gistr#authentication}.}
 
 \item{language}{Which language to use in visualization? So far: \code{english} or \code{polish}.}
+
+\item{use.bytes}{Should \code{writeLines} be used instead of {cat} to write the json file? 
+If running on windows cat will encode in ansi which might not preserve special characters 
+in the corpus. If set to true \code{writeLines} will be used to produce an utf-8 encoded file.}
 
 \item{...}{arguments passed onto \code{gistr::gist_create}}
 }

--- a/man/serVis.Rd
+++ b/man/serVis.Rd
@@ -5,7 +5,7 @@
 \title{View and/or share LDAvis in a browser}
 \usage{
 serVis(json, out.dir = tempfile(), open.browser = interactive(),
-  as.gist = FALSE, language = "english", use.bytes = FALSE, ...)
+  as.gist = FALSE, language = "english", ...)
 }
 \arguments{
 \item{json}{character string output from \link{createJSON}.}
@@ -22,10 +22,6 @@ interactive login if the GITHUB_PAT environment variable is not set. For more
 details, see \url{https://github.com/ropensci/gistr#authentication}.}
 
 \item{language}{Which language to use in visualization? So far: \code{english} or \code{polish}.}
-
-\item{use.bytes}{Should \code{writeLines} be used instead of {cat} to write the json file? 
-If running on windows cat will encode in ansi which might not preserve special characters 
-in the corpus. If set to true \code{writeLines} will be used to produce an utf-8 encoded file.}
 
 \item{...}{arguments passed onto \code{gistr::gist_create}}
 }


### PR DESCRIPTION
When on windows r does not encode created files as utf-8 by default (see [this stackoverflow post](https://stackoverflow.com/a/25507009/3176892)).
This is rather annoying when working with texts that are not in english e.g. german where there are a lot of umlaute ('ö', 'ä' etc.)
To work around this i've added the `use.bytes` argument which will make `serVis` use `writeLines` with `useBytes = TRUE` if set. This works around the problem and encodes the json file in utf-8.

I've added documentation for this argument in `man/serVis.R` but as i'm fairly new to r librarys i might have missed something.