### PR TITLE
Do division in log space

### DIFF
--- a/R/createJSON.R
+++ b/R/createJSON.R
@@ -300,7 +300,7 @@ jsPCA <- function(phi) {
   # http://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence
   jensenShannon <- function(x, y) {
     m <- 0.5*(x + y)
-    0.5*sum(x*log(x/m)) + 0.5*sum(y*log(y/m))
+    0.5*sum(x*(log(x)-log(m))) + 0.5*sum(y*(log(y)-log(m)))
   }
   dist.mat <- proxy::dist(x = phi, method = jensenShannon)
   # then, we reduce the K by K proximity matrix down to K by 2 using PCA


### PR DESCRIPTION
This is more precise and reduces the probability of underflow. There are other opportunities to make this same improvement in the JS, but I haven't run into any issues there.