### PR TITLE
Add stand.alone argument to serVis()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ LazyData: true
 VignetteBuilder: knitr
 URL: https://github.com/cpsievert/LDAvis
 BugReports: https://github.com/cpsievert/LDAvis/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 7.3.0

--- a/man/TwentyNewsgroups.Rd
+++ b/man/TwentyNewsgroups.Rd
@@ -4,14 +4,16 @@
 \name{TwentyNewsgroups}
 \alias{TwentyNewsgroups}
 \title{Twenty Newsgroups Data}
-\format{A list elements extracted from a topic model fit to this data
+\format{
+A list elements extracted from a topic model fit to this data
 \describe{
   \item{phi}{phi, a matrix with the topic-term distributions}
   \item{theta}{theta, a matrix with the document-topic distributions}
   \item{doc.length}{doc.length, a numeric vector with token counts for each document}
   \item{vocab}{vocab, a character vector containing the terms}
   \item{term.frequency}{term.frequency, a numeric vector of observed term frequencies}
-}}
+}
+}
 \source{
 \url{http://qwone.com/~jason/20Newsgroups/}
 }

--- a/man/createJSON.Rd
+++ b/man/createJSON.Rd
@@ -4,10 +4,20 @@
 \alias{createJSON}
 \title{Create the JSON object to read into the javascript visualization}
 \usage{
-createJSON(phi = matrix(), theta = matrix(), doc.length = integer(),
-  vocab = character(), term.frequency = integer(), R = 30,
-  lambda.step = 0.01, mds.method = jsPCA, cluster, plot.opts = list(xlab =
-  "PC1", ylab = "PC2"), reorder.topics = TRUE, ...)
+createJSON(
+  phi = matrix(),
+  theta = matrix(),
+  doc.length = integer(),
+  vocab = character(),
+  term.frequency = integer(),
+  R = 30,
+  lambda.step = 0.01,
+  mds.method = jsPCA,
+  cluster,
+  plot.opts = list(xlab = "PC1", ylab = "PC2"),
+  reorder.topics = TRUE,
+  ...
+)
 }
 \arguments{
 \item{phi}{matrix, with each row containing the distribution over terms 

--- a/man/serVis.Rd
+++ b/man/serVis.Rd
@@ -4,9 +4,16 @@
 \alias{serVis}
 \title{View and/or share LDAvis in a browser}
 \usage{
-serVis(json, out.dir = tempfile(), open.browser = interactive(),
-  as.gist = FALSE, language = "english", encoding = getOption("encoding"),
-  ...)
+serVis(
+  json,
+  out.dir = tempfile(),
+  open.browser = interactive(),
+  stand.alone = FALSE,
+  as.gist = FALSE,
+  language = "english",
+  encoding = getOption("encoding"),
+  ...
+)
 }
 \arguments{
 \item{json}{character string output from \link{createJSON}.}
@@ -17,6 +24,8 @@ serVis(json, out.dir = tempfile(), open.browser = interactive(),
 attempt to create a local file server via the servr package.
 This is necessary since the javascript needs to access local files and most 
 browsers will not allow this.}
+
+\item{stand.alone}{should the output be contained in a single html file?}
 
 \item{as.gist}{should the vis be uploaded as a gist? Will prompt for an 
 interactive login if the GITHUB_PAT environment variable is not set. For more


### PR DESCRIPTION
Added a `stand.alone` argument to `serVis()` to produce a stand alone html file with all includes provided inline. This makes sharing results with others easier and avoids [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) ([CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS)) errors as in #100.